### PR TITLE
Rename duplicate argument names

### DIFF
--- a/rustkit_bindgen/src/lib.rs
+++ b/rustkit_bindgen/src/lib.rs
@@ -640,10 +640,16 @@ impl MethodDecl {
             Ident::new(&selname, Span::call_site());
         let mut params: Vec<syn::FnArg> =
             (&self.args).iter().
-            map(|a| {
-                let name = Ident::new(&a.name, Span::call_site());
+            scan(Vec::new(), |names, a| {
+                let name = &a.name;
+                let name = match names.iter().filter(|n| **n == name).count() {
+                    0 => name.to_string(),
+                    n => format!("{}_{}", name, n + 1)
+                };
+                names.push(&a.name);
+                let name = Ident::new(&name, Span::call_site());
                 let rawty = a.ty.rust_ty(false);
-                parse_quote!{ #name : #rawty }
+                Some(parse_quote!{ #name : #rawty })
             }).collect();
         if !initializer && !class {
             params.insert(0, parse_quote!{ &self });


### PR DESCRIPTION
Let me preface this by making it clear that I have no idea what I’m doing! Still new to Rust and I don’t understand much about Obj-C interop.

I’m trying out different ways of working with Cocoa and I came across these bindings, looking really good. I ran into some difficulties getting AppKit to work, rustc doesn’t like duplicate argument names:

```
   Compiling rustkit v0.0.1 (https://github.com/michaelwu/RustKit?rev=fd7364800c1c31718aabaa23757f7bd20db59d3b#fd736480)
error[E0415]: identifier `name` is bound more than once in this parameter list
     --> ./target/debug/build/rustkit-e42b5beac1d8b484/out/AppKit.rs:76942:9
      |
76942 |         name: &NSString,
      |         ^^^^ used as parameter more than once
```

Here’s the generated signature:

```rust
    pub fn renameFontCollectionWithName_visibility_toName_error_(
        name: &NSString,
        visibility: NSFontCollectionVisibility,
        name: &NSString,
        error: Option<&mut &Option<Arc<NSError>>>,
    ) -> bool {
```

I changed the generator to append numbers to each duplicated argument to get around this. The code is probably a little wonky, please suggest any improvements. That said, I still can’t get AppKit to work but this is probably a separate issue. Here’s my little testcase:

```rust
extern crate rustkit;

use rustkit::AppKit::NSApplication;
use rustkit::AppKit::NSApplicationActivationPolicy::NSApplicationActivationPolicyRegular;

fn main() {
    let app = NSApplication::sharedApplication();
    app.setActivationPolicy_(NSApplicationActivationPolicyRegular);
    app.run();
}
```

Now it seems to crash due to unregistered selectors, but at least the bindings work:

```
2019-03-03 20:12:40.888 appkit[15155:116850] *** NSForwarding: warning: selector (0x10725cd65) for message 'sharedApplication' does not match selector known to Objective C runtime (0x7fff4b587a4c)-- abort
2019-03-03 20:12:40.888 appkit[15155:116850] +[NSApplication sharedApplication]: unrecognized selector sent to class 0x7fffa58f0778                                          
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/libcore/option.rs:345:21                                                                            
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
fatal runtime error: failed to initiate panic, error 5
fish: 'cargo run' terminated by signal SIGABRT (Abort)
```